### PR TITLE
Coverage Badge Updating

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,19 @@ jobs:
         run: |
           python src/badge_generator.py
 
+      - name: Check for changes in coverage badge
+        id: check_changes
+        run: |
+          if git diff --exit-code -- coverage-badge.svg; then
+            echo "No changes in coverage badge"
+            echo "::set-output name=changes::false"
+          else
+            echo "Changes detected in coverage badge"
+            echo "::set-output name=changes::true"
+          fi
+
       - name: Commit coverage badge
+        if: steps.check_changes.outputs.changes == 'true'
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
This PR fixes bug that can be reproduced as follows:
1. Commit some changes to the `master` branch
2. These changes DO NOT change tests coverage (e.g. only `README.md`, or documentation)
3. Push changes to the `master` branch

![image](https://github.com/user-attachments/assets/8f032a4b-2157-4e9f-a16e-b68a32bf005e)

I suppose to fix it as follows:
1. Add new `Check for changes in coverage badge` step with id `check_changes` to identify whether changes in coverage badge were made
2. Add condition for `Commit coverage badge` step